### PR TITLE
[WIP] Include comments in formatter output

### DIFF
--- a/ast/attachment_test.go
+++ b/ast/attachment_test.go
@@ -210,6 +210,7 @@ func TestAttachExpressionMarshallJSON(t *testing.T) {
 				"foo",
 				Position{Offset: 1, Line: 2, Column: 3},
 			),
+			Comments{},
 		),
 		Attachment: NewInvocationExpression(
 			nil,
@@ -220,6 +221,7 @@ func TestAttachExpressionMarshallJSON(t *testing.T) {
 					"bar",
 					Position{Offset: 1, Line: 2, Column: 3},
 				),
+				Comments{},
 			),
 			[]*TypeAnnotation{},
 			Arguments{},
@@ -285,6 +287,7 @@ func TestAttachExpression_Doc(t *testing.T) {
 				"foo",
 				Position{Offset: 1, Line: 2, Column: 3},
 			),
+			Comments{},
 		),
 		Attachment: NewInvocationExpression(
 			nil,
@@ -295,6 +298,7 @@ func TestAttachExpression_Doc(t *testing.T) {
 					"bar",
 					Position{Offset: 1, Line: 2, Column: 3},
 				),
+				Comments{},
 			),
 			[]*TypeAnnotation{},
 			Arguments{},
@@ -345,6 +349,7 @@ func TestRemoveStatement_MarshallJSON(t *testing.T) {
 				"baz",
 				Position{Offset: 1, Line: 2, Column: 3},
 			),
+			Comments{},
 		),
 		StartPos: Position{Offset: 1, Line: 2, Column: 3},
 	}
@@ -406,6 +411,7 @@ func TestRemoveStatement_Doc(t *testing.T) {
 				"baz",
 				Position{Offset: 1, Line: 2, Column: 3},
 			),
+			Comments{},
 		),
 		StartPos: Position{Offset: 1, Line: 2, Column: 3},
 	}

--- a/ast/block.go
+++ b/ast/block.go
@@ -20,7 +20,6 @@ package ast
 
 import (
 	"encoding/json"
-
 	"github.com/turbolent/prettier"
 
 	"github.com/onflow/cadence/common"
@@ -61,14 +60,18 @@ var blockEndDoc prettier.Doc = prettier.Text("}")
 var blockEmptyDoc prettier.Doc = prettier.Text("{}")
 
 func (b *Block) Doc() prettier.Doc {
-	if b.IsEmpty() {
+	if b.IsEmpty() && b.Comments.IsEmpty() {
 		return blockEmptyDoc
 	}
+
+	var statementsDoc prettier.Concat
+	statementsDoc = append(statementsDoc, b.Comments.LeadingDoc())
+	statementsDoc = append(statementsDoc, StatementsDoc(b.Statements))
 
 	return prettier.Concat{
 		blockStartDoc,
 		prettier.Indent{
-			Doc: StatementsDoc(b.Statements),
+			Doc: statementsDoc,
 		},
 		prettier.HardLine{},
 		blockEndDoc,
@@ -170,7 +173,7 @@ var preConditionsKeywordDoc = prettier.Text("pre")
 var postConditionsKeywordDoc = prettier.Text("post")
 
 func (b *FunctionBlock) Doc() prettier.Doc {
-	if b.IsEmpty() {
+	if b.IsEmpty() && b.Block.Comments.IsEmpty() {
 		return blockEmptyDoc
 	}
 
@@ -194,7 +197,9 @@ func (b *FunctionBlock) Doc() prettier.Doc {
 
 	var bodyDoc prettier.Doc
 
-	statementsDoc := StatementsDoc(b.Block.Statements)
+	var statementsDoc prettier.Concat
+	statementsDoc = append(statementsDoc, CommentsToDoc(b.Block.Comments.PackToList()))
+	statementsDoc = append(statementsDoc, StatementsDoc(b.Block.Statements))
 
 	if len(conditionDocs) > 0 {
 		bodyConcatDoc := prettier.Concat(conditionDocs)

--- a/ast/block.go
+++ b/ast/block.go
@@ -65,7 +65,7 @@ func (b *Block) Doc() prettier.Doc {
 	}
 
 	var statementsDoc prettier.Concat
-	statementsDoc = append(statementsDoc, b.Comments.LeadingDoc())
+	statementsDoc = append(statementsDoc, CommentsToDoc(b.Comments.PackToList()))
 	statementsDoc = append(statementsDoc, StatementsDoc(b.Statements))
 
 	return prettier.Concat{

--- a/ast/comments.go
+++ b/ast/comments.go
@@ -3,6 +3,7 @@ package ast
 import (
 	"bytes"
 	"github.com/onflow/cadence/common"
+	"github.com/turbolent/prettier"
 	"strings"
 )
 
@@ -30,6 +31,16 @@ func (c Comments) LeadingDocString() string {
 		}
 	}
 	return s.String()
+}
+
+// LeadingDoc prints the leading comments prettier document
+func (c Comments) LeadingDoc() prettier.Doc {
+	var doc prettier.Concat
+	for _, c := range c.Leading {
+		doc = append(doc, prettier.Text(c.source))
+		doc = append(doc, prettier.HardLine{})
+	}
+	return doc
 }
 
 type Comment struct {

--- a/ast/comments.go
+++ b/ast/comments.go
@@ -51,6 +51,7 @@ func (c Comments) LeadingDoc() prettier.Doc {
 	return doc
 }
 
+// CommentsToDoc TODO(output-comments): Consolidate these helper functions
 func CommentsToDoc(comments []*Comment) prettier.Doc {
 	var doc prettier.Concat
 	for _, c := range comments {

--- a/ast/comments.go
+++ b/ast/comments.go
@@ -16,6 +16,8 @@ func (c Comments) IsEmpty() bool {
 	return len(c.Trailing) == 0 && len(c.Leading) == 0
 }
 
+// PackToList concatenates leading and trailing comments into a single slice
+// TODO(output-comments): Rename to PackToList
 func (c Comments) PackToList() []*Comment {
 	var comments []*Comment
 	comments = append(comments, c.Leading...)
@@ -75,6 +77,7 @@ var lineCommentDocStringPrefix = []byte("///")
 var lineCommentStringPrefix = []byte("//")
 var blockCommentStringSuffix = []byte("*/")
 
+// Multiline TODO(output-comments): Should we rename to Inline() ?
 func (c Comment) Multiline() bool {
 	return bytes.HasPrefix(c.source, blockCommentStringPrefix)
 }

--- a/ast/comments.go
+++ b/ast/comments.go
@@ -12,6 +12,10 @@ type Comments struct {
 	Trailing []*Comment `json:"-"`
 }
 
+func (c Comments) IsEmpty() bool {
+	return len(c.Trailing) == 0 && len(c.Leading) == 0
+}
+
 func (c Comments) PackToList() []*Comment {
 	var comments []*Comment
 	comments = append(comments, c.Leading...)
@@ -39,6 +43,15 @@ func (c Comments) LeadingDoc() prettier.Doc {
 	for _, c := range c.Leading {
 		doc = append(doc, prettier.Text(c.source))
 		doc = append(doc, prettier.HardLine{})
+	}
+	return doc
+}
+
+func CommentsToDoc(comments []*Comment) prettier.Doc {
+	var doc prettier.Concat
+	for _, c := range comments {
+		doc = append(doc, prettier.HardLine{})
+		doc = append(doc, prettier.Text(c.source))
 	}
 	return doc
 }

--- a/ast/comments.go
+++ b/ast/comments.go
@@ -42,7 +42,9 @@ func (c Comments) LeadingDoc() prettier.Doc {
 	var doc prettier.Concat
 	for _, c := range c.Leading {
 		doc = append(doc, prettier.Text(c.source))
-		doc = append(doc, prettier.HardLine{})
+		if !c.Multiline() {
+			doc = append(doc, prettier.HardLine{})
+		}
 	}
 	return doc
 }

--- a/ast/composite.go
+++ b/ast/composite.go
@@ -149,11 +149,16 @@ func (d *CompositeDeclaration) Doc() prettier.Doc {
 		d.Identifier.Identifier,
 		d.Conformances,
 		d.Members,
+		d.Comments,
 	)
 }
 
 func (d *CompositeDeclaration) EventDoc() prettier.Doc {
 	var doc prettier.Concat
+
+	if len(d.Comments.Leading) > 0 {
+		doc = append(doc, d.Comments.LeadingDoc())
+	}
 
 	if d.Access != AccessNotSpecified {
 		doc = append(
@@ -199,9 +204,14 @@ func CompositeDocument(
 	identifier string,
 	conformances []*NominalType,
 	members *Members,
+	comments Comments,
 ) prettier.Doc {
 
 	var doc prettier.Concat
+
+	if len(comments.Leading) > 0 {
+		doc = append(doc, comments.LeadingDoc())
+	}
 
 	if access != AccessNotSpecified {
 		doc = append(

--- a/ast/expression.go
+++ b/ast/expression.go
@@ -671,6 +671,7 @@ func (e DictionaryEntry) Doc() prettier.Doc {
 
 type IdentifierExpression struct {
 	Identifier Identifier
+	Comments   Comments
 }
 
 var _ Element = &IdentifierExpression{}
@@ -679,11 +680,13 @@ var _ Expression = &IdentifierExpression{}
 func NewIdentifierExpression(
 	gauge common.MemoryGauge,
 	identifier Identifier,
+	comments Comments,
 ) *IdentifierExpression {
 	common.UseMemory(gauge, common.IdentifierExpressionMemoryUsage)
 
 	return &IdentifierExpression{
 		Identifier: identifier,
+		Comments:   comments,
 	}
 }
 

--- a/ast/expression.go
+++ b/ast/expression.go
@@ -707,7 +707,15 @@ func (e *IdentifierExpression) String() string {
 }
 
 func (e *IdentifierExpression) Doc() prettier.Doc {
-	return prettier.Text(e.Identifier.Identifier)
+	var doc prettier.Concat
+
+	if len(e.Comments.Leading) > 0 {
+		doc = append(doc, e.Comments.LeadingDoc())
+	}
+
+	doc = append(doc, prettier.Text(e.Identifier.Identifier))
+
+	return doc
 }
 
 func (e *IdentifierExpression) MarshalJSON() ([]byte, error) {

--- a/ast/expression.go
+++ b/ast/expression.go
@@ -1480,6 +1480,7 @@ func FunctionDocument(
 	parameterList *ParameterList,
 	returnTypeAnnotation *TypeAnnotation,
 	block *FunctionBlock,
+	comments *Comments,
 ) prettier.Doc {
 
 	var signatureDoc prettier.Concat
@@ -1515,6 +1516,13 @@ func FunctionDocument(
 	}
 
 	var doc prettier.Concat
+
+	if comments != nil {
+		doc = append(
+			doc,
+			comments.LeadingDoc(),
+		)
+	}
 
 	if access != AccessNotSpecified {
 		doc = append(
@@ -1596,6 +1604,7 @@ func (e *FunctionExpression) Doc() prettier.Doc {
 		e.ParameterList,
 		e.ReturnTypeAnnotation,
 		e.FunctionBlock,
+		nil,
 	)
 }
 

--- a/ast/function_declaration.go
+++ b/ast/function_declaration.go
@@ -190,6 +190,7 @@ func (d *FunctionDeclaration) Doc() prettier.Doc {
 		d.ParameterList,
 		d.ReturnTypeAnnotation,
 		d.FunctionBlock,
+		&d.Comments,
 	)
 }
 
@@ -302,6 +303,7 @@ func (d *SpecialFunctionDeclaration) Doc() prettier.Doc {
 		d.FunctionDeclaration.ParameterList,
 		d.FunctionDeclaration.ReturnTypeAnnotation,
 		d.FunctionDeclaration.FunctionBlock,
+		&d.FunctionDeclaration.Comments,
 	)
 }
 

--- a/ast/function_declaration_test.go
+++ b/ast/function_declaration_test.go
@@ -298,7 +298,11 @@ func TestFunctionDeclaration_Doc(t *testing.T) {
 		Identifier: Identifier{
 			Identifier: "xyz",
 		},
-
+		Comments: Comments{
+			Leading: []*Comment{
+				NewComment(nil, []byte("// before xyz")),
+			},
+		},
 		ParameterList: &ParameterList{
 			Parameters: []*Parameter{
 				{
@@ -327,12 +331,18 @@ func TestFunctionDeclaration_Doc(t *testing.T) {
 		FunctionBlock: &FunctionBlock{
 			Block: &Block{
 				Statements: []Statement{},
+				Comments: Comments{
+					Leading:  []*Comment{NewComment(nil, []byte("// body start"))},
+					Trailing: []*Comment{NewComment(nil, []byte("// body end"))},
+				},
 			},
 		},
 	}
 
 	require.Equal(t,
 		prettier.Concat{
+			prettier.Text("// before xyz"),
+			prettier.HardLine{},
 			prettier.Text("access(all)"),
 			prettier.HardLine{},
 			prettier.Text("view"),

--- a/ast/interface.go
+++ b/ast/interface.go
@@ -120,6 +120,7 @@ func (d *InterfaceDeclaration) Doc() prettier.Doc {
 		d.Identifier.Identifier,
 		d.Conformances,
 		d.Members,
+		d.Comments,
 	)
 }
 

--- a/ast/parameter.go
+++ b/ast/parameter.go
@@ -32,7 +32,7 @@ type Parameter struct {
 	Label           string
 	Identifier      Identifier
 	StartPos        Position `json:"-"`
-	Comments
+	Comments        Comments
 }
 
 func NewParameter(
@@ -98,6 +98,11 @@ const parameterDefaultArgumentSeparator = "="
 
 func (p *Parameter) Doc() prettier.Doc {
 	var parameterDoc prettier.Concat
+
+	if !p.Comments.IsEmpty() {
+		parameterDoc = append(parameterDoc, prettier.HardLine{})
+		parameterDoc = append(parameterDoc, p.Comments.LeadingDoc())
+	}
 
 	if p.Label != "" {
 		parameterDoc = append(

--- a/ast/parameter.go
+++ b/ast/parameter.go
@@ -100,8 +100,13 @@ func (p *Parameter) Doc() prettier.Doc {
 	var parameterDoc prettier.Concat
 
 	if !p.Comments.IsEmpty() {
-		parameterDoc = append(parameterDoc, prettier.HardLine{})
-		parameterDoc = append(parameterDoc, p.Comments.LeadingDoc())
+		if !p.Comments.PackToList()[0].Multiline() {
+			parameterDoc = append(parameterDoc, prettier.HardLine{})
+			parameterDoc = append(parameterDoc, p.Comments.LeadingDoc())
+		} else {
+			parameterDoc = append(parameterDoc, p.Comments.LeadingDoc())
+			parameterDoc = append(parameterDoc, prettier.Text(" "))
+		}
 	}
 
 	if p.Label != "" {

--- a/ast/statement.go
+++ b/ast/statement.go
@@ -271,12 +271,21 @@ const ifStatementSpaceElseKeywordSpaceDoc = prettier.Text(" else ")
 func (s *IfStatement) Doc() prettier.Doc {
 	testDoc := s.Test.Doc()
 
-	doc := prettier.Concat{
-		ifStatementIfKeywordSpaceDoc,
-		testDoc,
-		prettier.Space,
-		s.Then.Doc(),
+	doc := prettier.Concat{}
+
+	if len(s.Comments.Leading) > 0 {
+		doc = append(doc, s.Comments.LeadingDoc())
 	}
+
+	doc = append(
+		doc,
+		prettier.Concat{
+			ifStatementIfKeywordSpaceDoc,
+			testDoc,
+			prettier.Space,
+			s.Then.Doc(),
+		},
+	)
 
 	if s.Else != nil && len(s.Else.Statements) > 0 {
 		var elseDoc prettier.Doc
@@ -405,7 +414,7 @@ type ForStatement struct {
 	Block      *Block
 	Identifier Identifier
 	StartPos   Position `json:"-"`
-	Comments
+	Comments   Comments
 }
 
 var _ Element = &ForStatement{}
@@ -455,9 +464,13 @@ const forStatementForKeywordSpaceDoc = prettier.Text("for ")
 const forStatementSpaceInKeywordSpaceDoc = prettier.Text(" in ")
 
 func (s *ForStatement) Doc() prettier.Doc {
-	doc := prettier.Concat{
-		forStatementForKeywordSpaceDoc,
+	doc := prettier.Concat{}
+
+	if len(s.Comments.Leading) > 0 {
+		doc = append(doc, s.Comments.LeadingDoc())
 	}
+
+	doc = append(doc, forStatementForKeywordSpaceDoc)
 
 	if s.Index != nil {
 		doc = append(

--- a/ast/statement.go
+++ b/ast/statement.go
@@ -72,17 +72,19 @@ func (s *ReturnStatement) Walk(walkChild func(Element)) {
 }
 
 const returnStatementKeywordDoc = prettier.Text("return")
-const returnStatementKeywordSpaceDoc = prettier.Text("return ")
 
 func (s *ReturnStatement) Doc() prettier.Doc {
-	if s.Expression == nil {
-		return returnStatementKeywordDoc
+	var doc prettier.Concat
+
+	doc = append(doc, s.Comments.LeadingDoc())
+	doc = append(doc, returnStatementKeywordDoc)
+
+	if s.Expression != nil {
+		doc = append(doc, prettier.Space)
+		doc = append(doc, s.Expression.Doc())
 	}
 
-	return prettier.Concat{
-		returnStatementKeywordSpaceDoc,
-		s.Expression.Doc(),
-	}
+	return doc
 }
 
 func (s *ReturnStatement) String() string {

--- a/ast/variable_declaration.go
+++ b/ast/variable_declaration.go
@@ -218,6 +218,10 @@ func (d *VariableDeclaration) Doc() prettier.Doc {
 
 	var doc prettier.Concat
 
+	if !d.Comments.IsEmpty() {
+		doc = append(doc, d.Comments.LeadingDoc())
+	}
+
 	if d.Access != AccessNotSpecified {
 		doc = append(
 			doc,

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -840,6 +840,7 @@ func defineIdentifierExpression() {
 			return ast.NewIdentifierExpression(
 				p.memoryGauge,
 				p.tokenToIdentifier(token),
+				token.Comments,
 			), nil
 		},
 	})

--- a/parser/function.go
+++ b/parser/function.go
@@ -52,7 +52,7 @@ func parseParameterList(p *parser, expectDefaultArguments bool) (*ast.ParameterL
 	p.next()
 
 	expectParameter := true
-
+	var commaToken lexer.Token
 	var atEnd bool
 	progress := p.newProgress()
 
@@ -71,6 +71,7 @@ func parseParameterList(p *parser, expectDefaultArguments bool) (*ast.ParameterL
 			if err != nil {
 				return nil, err
 			}
+			parameter.Comments.Leading = append(parameter.Comments.Leading, commaToken.Comments.Trailing...)
 
 			parameters = append(parameters, parameter)
 			expectParameter = false
@@ -83,6 +84,7 @@ func parseParameterList(p *parser, expectDefaultArguments bool) (*ast.ParameterL
 				)
 			}
 			// Skip the comma
+			commaToken = p.current
 			p.next()
 			expectParameter = true
 

--- a/parser/prettier_test.go
+++ b/parser/prettier_test.go
@@ -220,14 +220,18 @@ fun main() {
 func TestPrettyIfStatement(t *testing.T) {
 	t.Run("line comments", func(t *testing.T) {
 		testPretty(t, `
-// before if
-if someCondition {
-	// noop
+fun main() {
+	// before if
+	if someCondition {
+		// noop
+	}
 }
 `, `
-// before if
-if someCondition {
-	// noop
+fun main() {
+    // before if
+    if someCondition {
+        // noop
+    }
 }
 `)
 	})
@@ -236,14 +240,18 @@ if someCondition {
 func TestPrettyForStatement(t *testing.T) {
 	t.Run("line comments", func(t *testing.T) {
 		testPretty(t, `
-// before for
-for x in y {
-	// noop
+fun main() {
+	// before for
+	for x in y {
+		// noop
+	}
 }
 `, `
-// before for
-for x in y {
-	// noop
+fun main() {
+    // before for
+    for x in y {
+        // noop
+    }
 }
 `)
 	})

--- a/parser/prettier_test.go
+++ b/parser/prettier_test.go
@@ -188,11 +188,15 @@ event Hello(/* before a */ a: String, /* before b */ b: String)
 func TestPrettyFunctionInvocation(t *testing.T) {
 	t.Run("line comments", func(t *testing.T) {
 		testPretty(t, `
-// say hello
-FooBar.hello()
+fun main() {
+	// say hello
+	FooBar.hello()
+}
 `, `
-// say hello
-FooBar.hello()
+fun main() {
+    // say hello
+    FooBar.hello()
+}
 `)
 	})
 }
@@ -200,11 +204,15 @@ FooBar.hello()
 func TestPrettyVariableAssignment(t *testing.T) {
 	t.Run("line comments", func(t *testing.T) {
 		testPretty(t, `
-// test message
-message = "Hello"
+fun main() {
+	// test message
+	message = "Hello"
+}
 `, `
-// test message
-message = "Hello"
+fun main() {
+    // test message
+    message = "Hello"
+}
 `)
 	})
 }

--- a/parser/prettier_test.go
+++ b/parser/prettier_test.go
@@ -30,7 +30,7 @@ fun multiply(
 			// TODO(output-comments): the closing args parenthesis should be in new line when there are comments or newlines between params?
 			// TODO(output-comments): omit the ending spaces when args are printed in separate lines due to comments
 			// TODO(output-comments): attach comments to expressions
-			strings.TrimSpace(`
+			`
 // Random comment
 
 // Function multiply
@@ -43,10 +43,10 @@ fun multiply(
 	// multiplies the params
     return x * y // multiply
 }
-`))
+`)
 	})
 
-	t.Run("multi declarations", func(t *testing.T) {
+	t.Run("multi declarations, with access", func(t *testing.T) {
 		testPretty(t, `
 // Function hello
 fun hello() {}
@@ -54,21 +54,218 @@ fun hello() {}
 // Random comment
 
 
+access(all)
 // Function bye
 fun bye() {}
-`, strings.TrimSpace(`
+`, `
 // Function hello
 fun hello() {}
 
 // Random comment
+access(all)
 // Function bye
 fun bye() {}
-`))
+`)
+	})
+}
+
+func TestPrettyVariableDeclaration(t *testing.T) {
+	t.Run("line comment", func(t *testing.T) {
+		testPretty(t, `
+// foo
+let foo: @AB = x
+`, `
+// foo
+let foo: @AB = x`)
+	})
+
+	t.Run("line comment, with access", func(t *testing.T) {
+		testPretty(t, `
+// foo
+access(all)
+let foo: @AB = x
+`, `
+// foo
+access(all)
+let foo: @AB = x`)
+	})
+}
+
+func TestPrettyContractDeclaration(t *testing.T) {
+	t.Run("line comment", func(t *testing.T) {
+		testPretty(t, `
+/// FooBar contract
+///
+access(all)
+contract FooBar : Foo, Bar {}
+`, `
+/// FooBar contract
+///
+access(all)
+contract FooBar : Foo, Bar {}
+`)
+	})
+}
+
+func TestPrettyEventDeclaration(t *testing.T) {
+	t.Run("line doc comment", func(t *testing.T) {
+		testPretty(t, `
+/// Hello event
+access(all)
+event Hello()
+`, `
+/// Hello event
+access(all)
+event Hello()
+`)
+	})
+
+	t.Run("param line comments", func(t *testing.T) {
+		testPretty(t, `
+/// Hello event
+access(all)
+event Hello(
+	// a
+	a: String,
+
+	// b
+	b: String,
+)
+`, `
+/// Hello event
+access(all)
+event Hello(
+	// a
+	a: String,
+	// b
+	b: String,
+)
+`)
+	})
+
+	t.Run("param line comments", func(t *testing.T) {
+		testPretty(t, `
+/// Hello event
+access(all)
+event Hello(/* before a */ a: String, /* before b */ b: String)
+`, `
+/// Hello event
+access(all)
+event Hello(/* before a */ a: String, /* before b */ b: String)
+`)
+	})
+}
+
+func TestPrettyFunctionInvocation(t *testing.T) {
+	t.Run("line comments", func(t *testing.T) {
+		testPretty(t, `
+// say hello
+FooBar.hello()
+`, `
+// say hello
+FooBar.hello()
+`)
+	})
+}
+
+func TestPrettyVariableAssignment(t *testing.T) {
+	t.Run("line comments", func(t *testing.T) {
+		testPretty(t, `
+// test message
+message = "Hello"
+`, `
+// test message
+message = "Hello"
+`)
+	})
+}
+
+func TestPrettyIfStatement(t *testing.T) {
+	t.Run("line comments", func(t *testing.T) {
+		testPretty(t, `
+// before if
+if someCondition {
+	// noop
+}
+`, `
+// before if
+if someCondition {
+	// noop
+}
+`)
+	})
+}
+
+func TestPrettyForStatement(t *testing.T) {
+	t.Run("line comments", func(t *testing.T) {
+		testPretty(t, `
+// before for
+for x in y {
+	// noop
+}
+`, `
+// before for
+for x in y {
+	// noop
+}
+`)
+	})
+}
+
+func TestPrettyCommentingPatterns(t *testing.T) {
+	t.Run("large section markers with spacing", func(t *testing.T) {
+		testPretty(t, `
+/**************************
+	  	Welcome
+**************************/
+
+/// Hello event
+event Hello()
+
+/**************************
+	  	Goodbye
+**************************/
+
+/// Bye event
+event Bye()
+`, `
+/**************************
+	  	Welcome
+**************************/
+
+/// Hello event
+event Hello()
+
+/**************************
+	  	Goodbye
+**************************/
+
+/// Bye event
+event Bye()
+`)
+	})
+
+	t.Run("inline section markers", func(t *testing.T) {
+		testPretty(t, `
+/* Welcome */
+//
+// Hello event
+event Hello()
+`, `
+/* Welcome */
+//
+// Hello event
+event Hello()
+`)
 	})
 }
 
 func testPretty(t *testing.T, source, expected string) {
-	program, err := ParseProgram(nil, []byte(source), Config{})
+	// trim ending and trailing spaces for easier use with template strings
+	s := strings.TrimSpace(source)
+	e := strings.TrimSpace(expected)
+
+	program, err := ParseProgram(nil, []byte(s), Config{})
 	require.NoError(t, err)
-	require.Equal(t, expected, ast.Prettier(program))
+	require.Equal(t, e, ast.Prettier(program))
 }

--- a/parser/prettier_test.go
+++ b/parser/prettier_test.go
@@ -46,6 +46,19 @@ fun multiply(
 `)
 	})
 
+	t.Run("inline comments for params", func(t *testing.T) {
+		testPretty(t, `
+fun multiply( /* first multiplier */ x: Int,  /* second multiplier */ y: Int): Int {
+    return x * y
+}
+`,
+			`
+fun multiply(/* first multiplier */ x: Int, /* second multiplier */ y: Int): Int {
+    return x * y
+}
+`)
+	})
+
 	t.Run("multi declarations, with access", func(t *testing.T) {
 		testPretty(t, `
 // Function hello

--- a/parser/prettier_test.go
+++ b/parser/prettier_test.go
@@ -149,6 +149,7 @@ event Hello()
 `)
 	})
 
+	// TODO(output-comments): Resolve same parameter printing issue as for the function test case
 	t.Run("param line comments", func(t *testing.T) {
 		testPretty(t, `
 /// Hello event
@@ -258,6 +259,8 @@ fun main() {
 }
 
 func TestPrettyCommentingPatterns(t *testing.T) {
+
+	// TODO(output-comments): Do we need to add newline tracking to the token/ast node comments (rename to trivia)?
 	t.Run("large section markers with spacing", func(t *testing.T) {
 		testPretty(t, `
 /**************************

--- a/parser/prettier_test.go
+++ b/parser/prettier_test.go
@@ -75,8 +75,8 @@ fun bye() {}
 fun hello() {}
 
 // Random comment
-access(all)
 // Function bye
+access(all)
 fun bye() {}
 `)
 	})

--- a/parser/prettier_test.go
+++ b/parser/prettier_test.go
@@ -105,7 +105,7 @@ let foo: @AB = x`)
 }
 
 func TestPrettyContractDeclaration(t *testing.T) {
-	t.Run("line comment", func(t *testing.T) {
+	t.Run("line doc comment", func(t *testing.T) {
 		testPretty(t, `
 /// FooBar contract
 ///
@@ -115,7 +115,23 @@ contract FooBar : Foo, Bar {}
 /// FooBar contract
 ///
 access(all)
-contract FooBar : Foo, Bar {}
+contract FooBar: Foo, Bar {}
+`)
+	})
+}
+
+func TestPrettyInterfaceDeclaration(t *testing.T) {
+	t.Run("line doc comment", func(t *testing.T) {
+		testPretty(t, `
+/// FooBar interface
+///
+access(all)
+contract interface FooBar {}
+`, `
+/// FooBar interface
+///
+access(all)
+contract interface FooBar {}
 `)
 	})
 }

--- a/parser/prettier_test.go
+++ b/parser/prettier_test.go
@@ -1,0 +1,74 @@
+package parser
+
+import (
+	"github.com/onflow/cadence/ast"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestPrettyFunctionDeclaration(t *testing.T) {
+
+	t.Run("with spaces, empty lines, line comments for params", func(t *testing.T) {
+		testPretty(t, `
+// Random comment
+
+// Function multiply
+fun multiply(
+
+		// first param
+	_ x: Int,
+
+		// second param
+	_ y: Int,
+): Int {
+		// multiplies the params
+
+    return x * y // multiply
+}
+`,
+			// TODO(output-comments): the closing args parenthesis should be in new line when there are comments or newlines between params?
+			// TODO(output-comments): omit the ending spaces when args are printed in separate lines due to comments
+			// TODO(output-comments): attach comments to expressions
+			strings.TrimSpace(`
+// Random comment
+
+// Function multiply
+fun multiply(
+	// first param
+	_ x: Int,
+	// second param
+	_ y: Int,
+): Int {
+	// multiplies the params
+    return x * y // multiply
+}
+`))
+	})
+
+	t.Run("multi declarations", func(t *testing.T) {
+		testPretty(t, `
+// Function hello
+fun hello() {}
+
+// Random comment
+
+
+// Function bye
+fun bye() {}
+`, strings.TrimSpace(`
+// Function hello
+fun hello() {}
+
+// Random comment
+// Function bye
+fun bye() {}
+`))
+	})
+}
+
+func testPretty(t *testing.T, source, expected string) {
+	program, err := ParseProgram(nil, []byte(source), Config{})
+	require.NoError(t, err)
+	require.Equal(t, expected, ast.Prettier(program))
+}

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -345,7 +345,7 @@ func parseIfStatement(p *parser) (*ast.IfStatement, error) {
 			switch string(p.currentTokenSource()) {
 			case KeywordLet, KeywordVar:
 				variableDeclaration, err =
-					parseVariableDeclaration(p, ast.AccessNotSpecified, nil)
+					parseVariableDeclaration(p, ast.AccessNotSpecified, nil, nil)
 				if err != nil {
 					return nil, err
 				}

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -630,8 +630,8 @@ func parseFunctionBlock(p *parser) (*ast.FunctionBlock, error) {
 				endToken.EndPos,
 			),
 			ast.Comments{
-				Leading:  startToken.Leading,
-				Trailing: endToken.Trailing,
+				Leading:  startToken.Comments.PackToList(),
+				Trailing: endToken.Comments.PackToList(),
 			},
 		),
 		preConditions,

--- a/parser/type.go
+++ b/parser/type.go
@@ -834,6 +834,7 @@ func parseNominalTypeInvocationRemainder(p *parser) (*ast.InvocationExpression, 
 	var invokedExpression ast.Expression = ast.NewIdentifierExpression(
 		p.memoryGauge,
 		ty.Identifier,
+		ty.Comments,
 	)
 
 	for _, nestedIdentifier := range ty.NestedIdentifiers {

--- a/sema/before_extractor.go
+++ b/sema/before_extractor.go
@@ -76,7 +76,7 @@ func (e *BeforeExtractor) ExtractInvocation(
 				ast.EmptyPosition,
 			)
 
-			newExpression := ast.NewIdentifierExpression(e.memoryGauge, newIdentifier)
+			newExpression := ast.NewIdentifierExpression(e.memoryGauge, newIdentifier, ast.Comments{})
 
 			extractedExpressions = append(extractedExpressions,
 				ast.ExtractedExpression{


### PR DESCRIPTION
## Description

Build upon the work of https://github.com/onflow/cadence/pull/3509 and include the retained AST node comments in the formatter output.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
